### PR TITLE
[SD-CLI] Use get_vae_mlir to generate Base Vae as well

### DIFF
--- a/shark/examples/shark_inference/stable_diffusion/opt_params.py
+++ b/shark/examples/shark_inference/stable_diffusion/opt_params.py
@@ -94,12 +94,8 @@ def get_vae():
         bucket_key, model_key, "vae", is_tuned, args.precision
     )
     if args.custom_model != "":
-        if args.use_base_vae:
-            return get_base_vae_mlir(model_name, iree_flags)
         return get_vae_mlir(model_name, iree_flags)
     if not args.use_tuned and args.import_mlir:
-        if args.use_base_vae:
-            return get_base_vae_mlir(model_name, iree_flags)
         return get_vae_mlir(model_name, iree_flags)
     return get_shark_model(bucket, model_name, iree_flags)
 


### PR DESCRIPTION
-- Current implementation unnecessarily implements a separate function
   to fetch Base Vae using `get_base_vae_mlir`.
-- This commit refactors the code to now only have one abstraction
   `get_vae_mlir` through which we'll obtain Base Vae as well.

Signed-off-by: Abhishek Varma <abhishek@nod-labs.com>